### PR TITLE
Add npm to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/awscdk"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## System Diagram
 
-![steam_game_prices_notifier drawio](https://github.com/user-attachments/assets/85e8c8e0-7dcd-4c9f-a83f-cecc637f6267)
+![steam_game_prices_notifier drawio](/docs/steam_game_prices_notifier.drawio.png)
 
 ## Application Description
 


### PR DESCRIPTION
The contents of the implementation in this PR are as follows:
- Add npm to dependabot
- Modify the way to show the system diagram in README