### PR TITLE
Add grouping for npm packages in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,16 @@ updates:
     directory: "/awscdk"
     schedule:
       interval: "weekly"
+    groups:
+      typescript:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+          - "constructs"
+      awscdk:
+        patterns:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+          - "constructs"


### PR DESCRIPTION
The contents of the implementation in this PR are as follows:
- Add grouping for npm packages in dependabot