### PR TITLE
Upgrade golangci-lint to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,21 +1,14 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    # Enabled by default
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-
-    # Disabled by default
     - bodyclose
     - containedctx
-    - gci
+    - errcheck
     - godox
-    - gofumpt
     - gosec
+    - govet
+    - ineffassign
     - ireturn
     - makezero
     - mirror
@@ -27,39 +20,51 @@ linters:
     - nonamedreturns
     - revive
     - sloglint
-    - tenv
-
-linters-settings:
-  gosec:
-    excludes:
-      - G115
-  revive:
-    ignore-generated-header: true
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: empty-block
-      - name: errorf
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-      - name: if-return
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
-      - name: time-naming
-      - name: unreachable-code
-      - name: var-declaration
-      - name: var-naming
-
-issues:
-  include:
-    - EXC0012
+    - staticcheck
+    - unused
+  settings:
+    gosec:
+      excludes:
+        - G115
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: errorf
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unreachable-code
+        - name: var-declaration
+        - name: var-naming
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
The contents of the implementation in this PR are as follows:
- Upgrade golangci-lint to v2