### PR TITLE
[feat] bump go version to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TsubasaBneAus/steam_game_price_notifier
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/aws/aws-lambda-go v1.50.0


### PR DESCRIPTION
The contents of the implementation in this PR are as follows:
- Bump Go version to 1.25.5